### PR TITLE
Correctly hook up button events

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -113,7 +113,7 @@ class App extends React.Component {
         menuItem: file.filename,
         render: () =>
           <Tab.Pane attached={true}>
-            <VisualizationPane sessionId={this.state.sessionId} fileId={file.id} files={this.props.files} results={this.props.results}/>
+            <VisualizationPane sessionId={this.state.sessionId} fileId={file.id} files={this.props.files} results={this.props.results} clearResults={this.clearResults}/>
           </Tab.Pane>
       }
     })

--- a/ui/src/components/pane/VisualizationPane.js
+++ b/ui/src/components/pane/VisualizationPane.js
@@ -89,7 +89,7 @@ class VizualizationPane extends React.Component {
         menuItem: "Data Status",
         render: () =>
           <Tab.Pane attached={true}>
-            <Table sessionId={this.props.sessionId} fileId={this.props.fileId} clearResults={this.clearResults}/>
+            <Table sessionId={this.props.sessionId} fileId={this.props.fileId} clearResults={this.props.clearResults}/>
           </Tab.Pane>
       },
       {


### PR DESCRIPTION
Moving the buttons from being a direct child of the APP.js control
to a child buried 2 layers deeper  disconnected the event. Since App.js
owns thecookies and session data, the event needs to be passed as a prop
 to be properly attached.

closes #291