### PR TITLE
Generalize Docker Hub and Codecov for forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,9 @@ name: buildx
 
 on:
   push:
-    branches: master
+    branches:
+      - master
+      - develop
     tags: 'v*'
 
 jobs:
@@ -12,25 +14,82 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Get the version
+      with:
+        fetch-depth: 0
+    - name: Get version number
       id: get_version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-    - name: Change for master
+      run: |
+        VERSION=$(git describe --tags)
+        echo VERSION=${VERSION}
+        echo ::set-output name=VERSION::${VERSION}
+        TAG_VERSION=$(git describe --abbrev=0 --tags)
+        echo TAG_VERSION=${TAG_VERSION}
+        echo ::set-output name=TAG_VERSION::${TAG_VERSION}
+        if [[ ${VERSION} == ${TAG_VERSION} ]]; then
+          IS_RELEASE="true"
+        else
+          IS_RELEASE="false"
+        fi
+        echo IS_RELEASE=${IS_RELEASE}
+        echo ::set-output name=IS_RELEASE::${IS_RELEASE}
+    - name: Should this workflow push to Docker Hub?
+      id: docker
+      env:
+        DOCKER_PASSWORD:  ${{ secrets.DOCKER_TOKEN }}
+        DOCKER_USERNAME:  ${{ secrets.DOCKER_USERNAME }}
+      run: |
+        PUSH_TO_DOCKER="false"
+        if [[ "${{ github.event_name }}" == "push" ]] &&
+           [[ -n $DOCKER_USERNAME ]] &&
+           [[ -n $DOCKER_PASSWORD ]] &&
+           [[ "${{ steps.get_version.outputs.IS_RELEASE }}" == "true" ]]
+        then
+          PUSH_TO_DOCKER="true"
+        fi
+        echo ::set-output name=PUSH_TO_DOCKER::${PUSH_TO_DOCKER}
+        echo PUSH_TO_DOCKER=${PUSH_TO_DOCKER}
+    - name: Change version for release on master
       id: change_version
-      run: if [ "${{ steps.get_version.outputs.VERSION }}" == "master" ]; then echo ::set-output name=VERSION::latest; else echo ::set-output name=VERSION::${{ steps.get_version.outputs.VERSION }}; fi
+      run: |
+        if [ "${GITHUB_REF##*/}" == "master" ]; then
+          echo ::set-output name=VERSION::latest;
+          echo VERSION=latest
+        else
+          echo ::set-output name=VERSION::${VERSION};
+          echo VERSION=${VERSION}
+        fi
+      env:
+        VERSION: ${{ steps.get_version.outputs.VERSION }}
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v3
       with:
         buildx-version: latest
         qemu-version: latest
+      if: steps.docker.outputs.PUSH_TO_DOCKER == 'true'
     - name: Docker Login
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
       run: |
         echo "${DOCKER_PASSWORD}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      if: github.repository == 'iqtlabs/packet_cafe' && github.event_name == 'push'
-
+      if: steps.docker.outputs.PUSH_TO_DOCKER == 'true'
+    - name: Build for test only
+      run: |
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_admin:${{ steps.change_version.outputs.VERSION }} admin && \
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_ui:${{ steps.change_version.outputs.VERSION }} ui && \
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_web:${{ steps.change_version.outputs.VERSION }} web && \
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_lb:${{ steps.change_version.outputs.VERSION }} lb && \
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_messenger:${{ steps.change_version.outputs.VERSION }} messenger && \
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_redis:${{ steps.change_version.outputs.VERSION }} redis && \
+        docker build \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_workers:${{ steps.change_version.outputs.VERSION }} workers
+      if: steps.docker.outputs.PUSH_TO_DOCKER == 'false'
     - name: Build and push platforms
       env:
         DOCKER_CLI_EXPERIMENTAL: enabled
@@ -38,29 +97,44 @@ jobs:
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_admin:${{ steps.change_version.outputs.VERSION }} admin && \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_admin:${{ steps.change_version.outputs.VERSION }} admin && \
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_ui:${{ steps.change_version.outputs.VERSION }} ui && \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_ui:${{ steps.change_version.outputs.VERSION }} ui && \
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_web:${{ steps.change_version.outputs.VERSION }} web && \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_web:${{ steps.change_version.outputs.VERSION }} web && \
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_lb:${{ steps.change_version.outputs.VERSION }} lb && \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_lb:${{ steps.change_version.outputs.VERSION }} lb && \
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_messenger:${{ steps.change_version.outputs.VERSION }} messenger && \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_messenger:${{ steps.change_version.outputs.VERSION }} messenger && \
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_redis:${{ steps.change_version.outputs.VERSION }} redis && \
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_redis:${{ steps.change_version.outputs.VERSION }} redis && \
         docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
           --push \
-          -t iqtlabs/packet_cafe_workers:${{ steps.change_version.outputs.VERSION }} workers
-      if: github.repository == 'iqtlabs/packet_cafe' && github.event_name == 'push'
+          -t ${{ secrets.DOCKER_USERNAME }}/packet_cafe_workers:${{ steps.change_version.outputs.VERSION }} workers
+      if: steps.docker.outputs.PUSH_TO_DOCKER == 'true'
+    - name: List available tags for images
+      env:
+        DOCKER_CLI_EXPERIMENTAL: enabled
+      run: |
+        for N in admin ui messenger web redis lb workers
+        do
+          image="${{ secrets.DOCKER_USERNAME }}/packet_cafe_${N}"
+          echo "${image}:" $(
+            wget -q https://registry.hub.docker.com/v1/repositories/${image}/tags -O - |
+              tr -d '[]" ' |
+              tr '}' '\n' |
+              awk -F: '{printf $3 " "}'
+          )
+        done
+      if: steps.docker.outputs.PUSH_TO_DOCKER == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,17 @@ jobs:
         docker run packet_cafe/web-test && \
         export PATH=/home/runner/.local/bin:$PATH
         #coverage report && coverage xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.6
+    - name: Using Codecov?
+      id: codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        unset USE_CODECOV
+        if [ -n $CODECOV_TOKEN ]; then USE_CODECOV='true'; fi
+        echo USE_CODECOV=${USE_CODECOV}
+        echo ::set-output name=USE_CODECOV::${USE_CODECOV}
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-      if: github.repository == 'iqtlabs/packet_cafe'
+      if: steps.codecov.outputs.USE_CODECOV


### PR DESCRIPTION
This is an attempt to generalize the GitHub workflows files to allow them to work with any fork. This is done by using the GitHub Secrets storage of Docker and Codecov credentials as the means of conditionally running steps rather than a hardcoded Docker Hub identifier. The `develop` branch is also used, as a means of development and testing of modifications to the Actions without having to use the `master` branch.

One thing that is not yet working the same way as in the prior workflow has to do with tagging images on Docker Hub. The previous workflow only worked off the `master` branch and tagged anything associated with the tag as `latest` on Docker Hub (without a matching numbered version, as is common with other Docker images). This current PR just tags with the version number. I think an additional step to tag the just-created builds from the `master` branch as `latest` (instead of doing an entirely new `buildx` run just to get images with the tag `latest`). Before I try to fix this bug, I wanted to discuss how you want this to work, but it should be good to go for testing on the `develop` branch.

How to test
------------

The multi-architecture build process is very time and resource-intensive. To reduce the load on GitHub Actions, and to assist in testing the container build process only, the multi-architecture build and push to Docker Hub is only invoked when two conditions are met. The user must:

1.  Set up Docker Hub credentials and
2. Tag the `master` or `develop` branch with a version number to be used for tagging images pushed to Docker Hub.

Any other push to either branch will simply run the `test` workflow and a single-architecture local build for testing purposes in the `buildx` workflow.

Interim and public test releases are made from the `develop` branch based when an annotated tag is pushed, while `latest` releases come from tags associated with the `master` branch are pushed.

In the GitHub Settings for your fork, create two Secrets to control Docker container creation and pushing to Docker Hub:

| Variable | Purpose |
|---------|----------|
| `DOCKER_USERNAME` | User (project) name for Docker Hub account |
| `DOCKER_TOKEN` | API token for accessing that Docker Hub account from GitHub |

Additionally, if you want to push test code coverage results to Codecov, create the following secret:

| Variable | Purpose |
|---------|----------|
| `CODECOV_TOKEN` | API token for accessing Codecov from GitHub |

If the Secrets `DOCKER_TOKEN` and `DOCKER_USERNAME` are not set, a single architecture build on the platform defined by `runs-on` will be performed to validate the build process for all containers works properly. No artifacts are saved.

If these Secrets are set and you push new tags for the `master` or`develop` branch, a “release" will be made for all defined architectures tagged with the annotated version number.

![buildx-tags](https://user-images.githubusercontent.com/1874225/90685099-23752f00-e21e-11ea-818d-aa879445571c.png)

If you do not have `CODECOV_TOKEN` set, no attempt will be made to publish Codecov results. Any repo fork can still have testing applied to the `master` and `develop` branches, regardless of whether Docker Hub or Codecov are being used.

