### PR TITLE
rewrite default nginx config with desired configuration

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -27,7 +27,7 @@ HEALTHCHECK --interval=15s --timeout=15s \
   CMD curl --silent --fail http://localhost:8001/api/v1 || exit 1
 
 COPY . /app
-COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY nginx/default.conf /etc/nginx/nginx.conf
 COPY nginx/proxy_params /etc/nginx/proxy_params
 RUN mkdir -p /run/nginx
 RUN touch /run/nginx/nginx.pid

--- a/web/nginx/default.conf
+++ b/web/nginx/default.conf
@@ -1,12 +1,120 @@
-server {
-    listen 8000;
-    server_name web;
-    client_max_body_size 4G;
-    keepalive_timeout 5;
+# /etc/nginx/nginx.conf
 
-    location / {
-        include proxy_params;
-        proxy_pass http://localhost:8001;
-        proxy_read_timeout 600;
+user nginx;
+
+# Set number of worker processes automatically based on number of CPU cores.
+worker_processes auto;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Configures default error logger.
+error_log /var/log/nginx/error.log warn;
+
+# Includes files with directives to load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Uncomment to include files with config snippets into the root context.
+# NOTE: This will be enabled by default in Alpine 3.15.
+#include /etc/nginx/conf.d/*.conf;
+
+events {
+    # The maximum number of simultaneous connections that can be opened by
+    # a worker process.
+    worker_connections 1024;
+}
+
+http {
+    # Includes mapping of file name extensions to MIME types of responses
+    # and defines the default type.
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Name servers used to resolve names of upstream servers into addresses.
+    # It's also needed when using tcpsocket and udpsocket in Lua modules.
+    #resolver 1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001;
+
+    # Don't tell nginx version to the clients. Default is 'on'.
+    server_tokens off;
+
+    # Specifies the maximum accepted body size of a client request, as
+    # indicated by the request header Content-Length. If the stated content
+    # length is greater than this size, then the client receives the HTTP
+    # error code 413. Set to 0 to disable. Default is '1m'.
+    client_max_body_size 1m;
+
+    # Sendfile copies data between one FD and other from within the kernel,
+    # which is more efficient than read() + write(). Default is off.
+    sendfile on;
+
+    # Causes nginx to attempt to send its HTTP response head in one packet,
+    # instead of using partial frames. Default is 'off'.
+    tcp_nopush on;
+
+
+    # Enables the specified protocols. Default is TLSv1 TLSv1.1 TLSv1.2.
+    # TIP: If you're not obligated to support ancient clients, remove TLSv1.1.
+    ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+
+    # Path of the file with Diffie-Hellman parameters for EDH ciphers.
+    # TIP: Generate with: `openssl dhparam -out /etc/ssl/nginx/dh2048.pem 2048`
+    #ssl_dhparam /etc/ssl/nginx/dh2048.pem;
+
+    # Specifies that our cipher suits should be preferred over client ciphers.
+    # Default is 'off'.
+    ssl_prefer_server_ciphers on;
+
+    # Enables a shared SSL cache with size that can hold around 8000 sessions.
+    # Default is 'none'.
+    ssl_session_cache shared:SSL:2m;
+
+    # Specifies a time during which a client may reuse the session parameters.
+    # Default is '5m'.
+    ssl_session_timeout 1h;
+
+    # Disable TLS session tickets (they are insecure). Default is 'on'.
+    ssl_session_tickets off;
+
+
+    # Enable gzipping of responses.
+    #gzip on;
+
+    # Set the Vary HTTP header as defined in the RFC 2616. Default is 'off'.
+    gzip_vary on;
+
+
+    # Helper variable for proxying websockets.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+
+    # Specifies the main log format.
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+            '$status $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+
+    # Sets the path, format, and configuration for a buffered log write.
+    access_log /var/log/nginx/access.log main;
+
+
+    # Includes virtual hosts configs.
+    #include /etc/nginx/http.d/*.conf;
+
+    server {
+        listen 8000;
+        server_name web;
+        client_max_body_size 4G;
+        keepalive_timeout 5;
+
+        location / {
+            include proxy_params;
+            proxy_pass http://localhost:8001;
+            proxy_read_timeout 600;
+        }
     }
 }
+
+# TIP: Uncomment if you use stream module.
+#include /etc/nginx/stream.conf;


### PR DESCRIPTION
change the way the web component's `nginx.conf` gets written to ensure that it uses the proper configuration. 