### PR TITLE
switch ui dockerfile to node lts

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine3.12
+FROM node:lts-alpine3.14
 LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
 
 RUN apk --no-cache upgrade && \
@@ -12,7 +12,7 @@ COPY . /app
 WORKDIR /app
 
 RUN npm cache verify
-#RUN npm install -g npm@latest --prefer-online
+RUN npm install -g npm@latest --prefer-online
 RUN npm ci --no-optional
 RUN npm run build
 


### PR DESCRIPTION
Switches the ui's `Dockerfile` to use `node:lts-alpine3.14` as it's base image in order to deal with: https://github.com/facebook/create-react-app/issues/11565. However, I think it makes more sense to continue to use the long term support base image at this point.